### PR TITLE
fix(ci): add explicit permissions blocks to GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions: {}
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-addon.yml
+++ b/.github/workflows/update-addon.yml
@@ -4,6 +4,9 @@ name: Send submodule updates to parent repo
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add top-level `permissions: {}` to `docker-image.yml` (restrictive default; job already has its own explicit permissions block)
- Add top-level `permissions: contents: write` to `update-addon.yml` (needs to push commits)

Restricts default `GITHUB_TOKEN` scope following the principle of least privilege.

Closes #73
Resolves https://github.com/anthony-spruyt/SunGather/security/code-scanning/2

## Test plan

- [ ] Verify `docker-image.yml` still builds/pushes on tag creation (job-level permissions override top-level `{}`)
- [ ] Verify `update-addon.yml` still works on manual dispatch

🤖 Generated with [Claude Code](https://claude.ai/claude-code)