### PR TITLE
fix(ci): use GitHub API for verified tag creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,10 +133,15 @@ jobs:
 
       - name: "Create git tag"
         env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           TAG: "${{ needs.resolve-version.outputs.tag }}"
+          REPO: "${{ github.repository }}"
+          SHA: "${{ github.sha }}"
         run: |
-          git tag "$TAG"
-          git push origin "$TAG"
+          gh api "repos/${REPO}/git/refs" \
+            --method POST \
+            -f "ref=refs/tags/${TAG}" \
+            -f "sha=${SHA}"
 
       - name: "Generate release notes"
         id: "notes"


### PR DESCRIPTION
## Summary
- Replace `git tag` + `git push` with `gh api repos/.../git/refs` in the release workflow
- Tags created via the GitHub REST API with `GITHUB_TOKEN` are automatically verified, satisfying the `required_signatures` tag ruleset

## Test Plan
- [ ] Trigger release workflow with patch bump, verify tag is created and shows as "verified"

🤖 Generated with [Claude Code](https://claude.com/claude-code)