### PR TITLE
fix: SungrowClient import crashes on startup

### DIFF
--- a/SunGather/sungather.py
+++ b/SunGather/sungather.py
@@ -117,7 +117,7 @@ def main():
     logging.debug(f'Inverter Config Loaded: {config_inverter}')
 
     if config_inverter.get('host'):
-        inverter = SungrowClient.SungrowClient(config_inverter)
+        inverter = SungrowClient(config_inverter)
     else:
         logging.error(f"Error: host option in config is required")
         sys.exit("Error: host option in config is required")

--- a/tests/test_import_integration.py
+++ b/tests/test_import_integration.py
@@ -6,3 +6,35 @@ def test_vendored_client_exposes_expected_api():
     assert hasattr(SungrowClient, 'scrape')
     assert hasattr(SungrowClient, 'connect')
     assert hasattr(SungrowClient, 'disconnect')
+
+
+def test_sungather_calls_sungrow_client_as_class_not_module_attr():
+    """sungather.py must call SungrowClient(config) directly, not SungrowClient.SungrowClient(config).
+
+    The import is 'from client.sungrow_client import SungrowClient' which gives
+    us the class. Calling SungrowClient.SungrowClient() is an AttributeError.
+    """
+    import ast
+    import os
+
+    sungather_path = os.path.join(
+        os.path.dirname(__file__), '..', 'SunGather', 'sungather.py'
+    )
+    with open(sungather_path) as f:
+        tree = ast.parse(f.read())
+
+    # Find all attribute accesses of the form SungrowClient.SungrowClient
+    bad_calls = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == 'SungrowClient'
+            and isinstance(node.value, ast.Name)
+            and node.value.id == 'SungrowClient'
+        ):
+            bad_calls.append(node.lineno)
+
+    assert bad_calls == [], (
+        f"sungather.py uses SungrowClient.SungrowClient on line(s) {bad_calls}. "
+        f"SungrowClient is imported as a class, not a module — call it directly."
+    )


### PR DESCRIPTION
## Summary

- Fix `AttributeError: type object 'SungrowClient' has no attribute 'SungrowClient'` crash on startup
- The pymodbus 3.x migration (3f8509f) changed the import to `from client.sungrow_client import SungrowClient` (the class directly) but line 120 still called `SungrowClient.SungrowClient(config)` as if it were the module
- Adds AST-based regression test to prevent this pattern from recurring

## Test plan

- [x] New test `test_sungather_calls_sungrow_client_as_class_not_module_attr` verified red/green cycle
- [x] All 27 tests passing
- [x] Pre-commit hooks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)