### PR TITLE
fix(ci): inject computed version into version.py during release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,12 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
 
+      - name: "Inject version into source"
+        env:
+          VERSION: "${{ needs.resolve-version.outputs.version }}"
+        run: |
+          printf "__version__ = '%s'\n" "$VERSION" > SunGather/version.py
+
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
 


### PR DESCRIPTION
The release workflow computed the version from git tags but never wrote it to SunGather/version.py before the Docker build, so every image shipped with the hardcoded 0.5.2.