### PR TITLE
fix(client): cipher send bypassed by pymodbus 3.x TransactionManager

### DIFF
--- a/SunGather/client/sungrow_modbus_tcp_client.py
+++ b/SunGather/client/sungrow_modbus_tcp_client.py
@@ -15,30 +15,28 @@ class SungrowModbusTcpClient(ModbusTcpClient):
         self._fifo = bytes()
         self._priv_key = priv_key
         self._key = None
-        self._orig_recv = self.recv
-        self._orig_send = self.send
+        self._aes_ecb = None
+        self._use_cipher = False
         self._key_date = date.today()
 
     def _setup(self):
         self._key = bytes(a ^ b for (a, b) in zip(self._pub_key, self._priv_key))
         self._aes_ecb = AES.new(self._key, AES.MODE_ECB)
         self._key_date = date.today()
-        self.send = self._send_cipher
-        self.recv = self._recv_decipher
+        self._use_cipher = True
         self._fifo = bytes()
 
     def _restore(self):
         self._key = None
         self._aes_ecb = None
-        self.send = self._orig_send
-        self.recv = self._orig_recv
+        self._use_cipher = False
         self._fifo = bytes()
 
     def _getkey(self):
         if (self._key is None) or (self._key_date != date.today()):
             self._restore()
-            self._orig_send(GET_KEY)
-            self._key_packet = self._orig_recv(25)
+            super().send(GET_KEY)
+            self._key_packet = super().recv(25)
             self._pub_key = self._key_packet[9:]
             if (len(self._pub_key) == 16) and \
                (self._pub_key != NO_CRYPTO1) and \
@@ -63,6 +61,16 @@ class SungrowModbusTcpClient(ModbusTcpClient):
     def close(self):
         super().close()
         self._fifo = bytes()
+
+    def send(self, request, addr=None):
+        if self._use_cipher:
+            return self._send_cipher(request, addr)
+        return super().send(request, addr)
+
+    def recv(self, size):
+        if self._use_cipher:
+            return self._recv_decipher(size)
+        return super().recv(size)
 
     def _send_cipher(self, request, addr=None):
         self._fifo = bytes()

--- a/tests/test_sungrow_modbus_tcp_client.py
+++ b/tests/test_sungrow_modbus_tcp_client.py
@@ -12,53 +12,72 @@ class TestSungrowModbusTcpClientInit:
 
     @patch('client.sungrow_modbus_tcp_client.ModbusTcpClient.__init__',
            return_value=None)
-    def test_init_stores_original_send_recv(self, mock_init):
-        """Init should store references to the original send/recv methods."""
+    def test_init_sets_cipher_off(self, mock_init):
+        """Init should start with cipher disabled."""
         client = SungrowModbusTcpClient.__new__(SungrowModbusTcpClient)
-        # Manually set attributes that __init__ would set via super()
-        client.send = MagicMock(name='original_send')
-        client.recv = MagicMock(name='original_recv')
         client.__init__(host='192.168.1.1')
-        assert client._orig_send is not None
-        assert client._orig_recv is not None
+        assert client._use_cipher is False
+        assert client._key is None
+        assert client._aes_ecb is None
 
 
 class TestEncryptionSetupRestore:
     @patch('client.sungrow_modbus_tcp_client.ModbusTcpClient.__init__',
            return_value=None)
-    def test_setup_swaps_to_cipher_methods(self, mock_init):
-        """After _setup(), send/recv should point to cipher methods."""
+    def test_setup_enables_cipher_flag(self, mock_init):
+        """After _setup(), _use_cipher should be True."""
         client = SungrowModbusTcpClient.__new__(SungrowModbusTcpClient)
-        client.send = MagicMock(name='original_send')
-        client.recv = MagicMock(name='original_recv')
-        client._orig_send = client.send
-        client._orig_recv = client.recv
         client._priv_key = b'Grow#0*2Sun68CbE'
         client._pub_key = b'\x01' * 16
         client._fifo = bytes()
+        client._use_cipher = False
 
         client._setup()
 
-        assert client.send == client._send_cipher
-        assert client.recv == client._recv_decipher
+        assert client._use_cipher is True
+        assert client._key is not None
+        assert client._aes_ecb is not None
 
     @patch('client.sungrow_modbus_tcp_client.ModbusTcpClient.__init__',
            return_value=None)
-    def test_restore_swaps_back_to_original(self, mock_init):
-        """After _restore(), send/recv should point back to originals."""
+    def test_restore_disables_cipher_flag(self, mock_init):
+        """After _restore(), _use_cipher should be False."""
         client = SungrowModbusTcpClient.__new__(SungrowModbusTcpClient)
-        orig_send = MagicMock(name='original_send')
-        orig_recv = MagicMock(name='original_recv')
-        client.send = orig_send
-        client.recv = orig_recv
-        client._orig_send = orig_send
-        client._orig_recv = orig_recv
         client._priv_key = b'Grow#0*2Sun68CbE'
         client._pub_key = b'\x01' * 16
         client._fifo = bytes()
+        client._use_cipher = False
 
         client._setup()
-        client._restore()
+        assert client._use_cipher is True
 
-        assert client.send == orig_send
-        assert client.recv == orig_recv
+        client._restore()
+        assert client._use_cipher is False
+        assert client._key is None
+        assert client._aes_ecb is None
+
+    @patch('client.sungrow_modbus_tcp_client.ModbusTcpClient.__init__',
+           return_value=None)
+    def test_send_delegates_to_cipher_when_enabled(self, mock_init):
+        """send() should call _send_cipher when cipher is active."""
+        client = SungrowModbusTcpClient.__new__(SungrowModbusTcpClient)
+        client._use_cipher = True
+        client._send_cipher = MagicMock(return_value=10)
+
+        result = client.send(b'\x00\x01\x00\x00\x00\x06\x01\x04\x00\x00\x00\x01')
+        client._send_cipher.assert_called_once()
+        assert result == 10
+
+    @patch('client.sungrow_modbus_tcp_client.ModbusTcpClient.__init__',
+           return_value=None)
+    @patch('client.sungrow_modbus_tcp_client.ModbusTcpClient.send',
+           return_value=12)
+    def test_send_delegates_to_parent_when_cipher_off(self, mock_send, mock_init):
+        """send() should call parent send when cipher is inactive."""
+        client = SungrowModbusTcpClient.__new__(SungrowModbusTcpClient)
+        client._use_cipher = False
+
+        request = b'\x00\x01\x00\x00\x00\x06\x01\x04\x00\x00\x00\x01'
+        result = client.send(request)
+        mock_send.assert_called_once_with(request, None)
+        assert result == 12


### PR DESCRIPTION
## Summary

- pymodbus 3.x `TransactionManager` captures `self.sync_client.send` as `low_level_send` **once at init time**
- The old approach of dynamically swapping `self.send = self._send_cipher` as an instance attribute was invisible to `low_level_send`
- All Modbus requests went out **unencrypted** for the `sungrow` connection type, causing "No response received after 3 retries" on every register read
- Replace dynamic method swapping with class-level `send()`/`recv()` methods that delegate based on a `_use_cipher` flag

## Test plan

- [x] All 29 existing tests pass
- [ ] Deploy to inverter using `sungrow` connection type and verify register reads succeed
- [ ] Verify `modbus` and `http` connection types still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)