### PR TITLE
fix: sanitize user input before logging to prevent log injection

### DIFF
--- a/SunGather/exports/webserver.py
+++ b/SunGather/exports/webserver.py
@@ -6,7 +6,13 @@ from urllib.parse import parse_qs, urlparse
 
 import json
 import logging
+import re
 import urllib
+
+
+def sanitize_for_log(value):
+    """Remove control characters to prevent log injection."""
+    return re.sub(r'[\r\n]+', ' ', str(value))
 
 class export_webserver(object):
     html_body = "Pending Data Retrieval"
@@ -116,7 +122,7 @@ class MyServer(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(bytes(export_webserver.config, "utf-8"))
             parsed_data = parse_qs(urlparse(self.path).query)
-            logging.info(f"{parsed_data}")
+            logging.info(sanitize_for_log(parsed_data))
         elif self.path.startswith('/json'):
             self.send_response(200)
             self.send_header("Content-type", "application/json")
@@ -138,8 +144,8 @@ class MyServer(BaseHTTPRequestHandler):
     def do_POST(self):
         length = int(self.headers['Content-Length'])
         post_data = urllib.parse.parse_qs(self.rfile.read(length).decode('utf-8'))
-        logging.info(f"{post_data}")
-        self.wfile.write(post_data.encode("utf-8"))
+        logging.info(sanitize_for_log(post_data))
+        self.wfile.write(json.dumps(post_data).encode("utf-8"))
 
     def log_message(self, format, *args):
         pass

--- a/SunGather/exports/webserver.py
+++ b/SunGather/exports/webserver.py
@@ -6,13 +6,12 @@ from urllib.parse import parse_qs, urlparse
 
 import json
 import logging
-import re
 import urllib
 
 
 def sanitize_for_log(value):
     """Remove control characters to prevent log injection."""
-    return re.sub(r'[\r\n]+', ' ', str(value))
+    return str(value).replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
 
 class export_webserver(object):
     html_body = "Pending Data Retrieval"

--- a/tests/test_log_injection.py
+++ b/tests/test_log_injection.py
@@ -1,0 +1,93 @@
+"""Tests for log injection sanitization in webserver export."""
+import logging
+import urllib.parse
+from io import BytesIO
+from http.server import HTTPServer
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from exports.webserver import MyServer, export_webserver, sanitize_for_log
+
+
+@pytest.fixture(autouse=True)
+def reset_webserver_state():
+    """Reset class-level state before each test."""
+    export_webserver.last_successful_scrape = None
+    export_webserver.scan_interval = 30
+    export_webserver.config = "<p>config</p>"
+
+
+class TestSanitizeForLog:
+    """The sanitize_for_log helper must strip control characters."""
+
+    def test_removes_newline(self):
+        assert "\n" not in sanitize_for_log("hello\nworld")
+
+    def test_removes_carriage_return(self):
+        assert "\r" not in sanitize_for_log("hello\rworld")
+
+    def test_removes_crlf(self):
+        result = sanitize_for_log("line1\r\nline2")
+        assert "\r" not in result
+        assert "\n" not in result
+
+    def test_preserves_normal_text(self):
+        assert sanitize_for_log("normal text") == "normal text"
+
+    def test_handles_dict_with_newlines(self):
+        data = {"key": ["value\nINJECTED"]}
+        result = sanitize_for_log(str(data))
+        assert "\n" not in result
+
+
+class TestGetConfigLogSanitized:
+    """Alert #3: GET /config must sanitize query data before logging."""
+
+    def test_config_query_logged_via_sanitize(self, caplog):
+        """Logging from /config must not contain raw newlines."""
+        handler = MyServer.__new__(MyServer)
+        handler.server = MagicMock(spec=HTTPServer)
+        handler.path = "/config?key=value%0aINJECTED"
+        handler.headers = {}
+        handler.requestline = "GET /config?key=value%0aINJECTED HTTP/1.1"
+        handler.request_version = "HTTP/1.1"
+        handler.command = "GET"
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.wfile = BytesIO()
+
+        with caplog.at_level(logging.INFO):
+            handler.do_GET()
+
+        for record in caplog.records:
+            assert "\n" not in record.message
+            assert "\r" not in record.message
+
+
+class TestPostLogSanitized:
+    """Alert #4: POST handler must sanitize body before logging."""
+
+    def test_post_body_logged_without_newlines(self, caplog):
+        """POST logging must not contain raw newlines from body."""
+        body = b"key=value%0aINJECTED"
+        handler = MyServer.__new__(MyServer)
+        handler.server = MagicMock(spec=HTTPServer)
+        handler.path = "/config"
+        handler.headers = {"Content-Length": str(len(body))}
+        handler.requestline = "POST /config HTTP/1.1"
+        handler.request_version = "HTTP/1.1"
+        handler.command = "POST"
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.rfile = BytesIO(body)
+        handler.wfile = BytesIO()
+
+        with caplog.at_level(logging.INFO):
+            handler.do_POST()
+
+        for record in caplog.records:
+            assert "\n" not in record.message
+            assert "\r" not in record.message


### PR DESCRIPTION
## Summary
- Fixes CodeQL alerts #3 and #4 (`py/log-injection`, high severity) in `SunGather/exports/webserver.py`
- Adds `sanitize_for_log()` helper that strips `\r` and `\n` from user-controlled data before logging, preventing log injection/forgery
- Fixes pre-existing bug in `do_POST` where `dict.encode()` was called instead of `json.dumps().encode()`

## Test plan
- [x] 7 new tests in `tests/test_log_injection.py` covering sanitizer and both HTTP handlers with malicious payloads
- [x] Full test suite passes (38 passed, 0 failures)
- [ ] Verify CodeQL re-scan closes alerts #3 and #4 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)