### PR TITLE
fix: correct trivy-action version comment to match pinned SHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
           cache-to: "type=gha,mode=max"
 
       - name: "Scan for vulnerabilities"
-        uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # v0.29
+        uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # v0.35.0
         with:
           image-ref: "sungather:ci"
           scanners: "vuln,secret,misconfig"

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Scan for vulnerabilities"
         if: "steps.check.outputs.exists == 'true'"
-        uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # v0.29
+        uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # v0.35.0
         with:
           image-ref: "${{ env.IMAGE }}"
           scanners: "vuln,secret,misconfig"


### PR DESCRIPTION
## Summary

- Fix Renovate lookup failure for `aquasecurity/trivy-action` caused by version comment/SHA mismatch
- The `# v0.29` comment didn't match the pinned SHA (`57a97c7`), which actually corresponds to `v0.35.0`
- Container-images repo doesn't have this issue because it omits the version comment entirely

## Test plan

- [ ] Verify Renovate dashboard no longer shows the `Could not determine new digest for update` warning after next Renovate run

🤖 Generated with [Claude Code](https://claude.com/claude-code)