### PR TITLE
feat: add cclsp Python LSP integration for Claude Code

### DIFF
--- a/.claude/cclsp.json
+++ b/.claude/cclsp.json
@@ -1,0 +1,10 @@
+{
+  "servers": [
+    {
+      "extensions": ["py"],
+      "command": ["pylsp"],
+      "rootDir": ".",
+      "restartInterval": 30
+    }
+  ]
+}

--- a/.devcontainer/setup-devcontainer.sh
+++ b/.devcontainer/setup-devcontainer.sh
@@ -2,3 +2,17 @@
 set -euo pipefail
 
 # Implement custom devcontainer setup here. This is run after the devcontainer has been created.
+
+# Install Python LSP server for cclsp
+# renovate: depName=python-lsp-server datasource=pypi
+PYLSP_VERSION="1.14.0"
+
+echo "Installing python-lsp-server ${PYLSP_VERSION}..."
+pipx install "python-lsp-server==${PYLSP_VERSION}"
+
+# Install cclsp (LSP-MCP bridge for AI coding agents)
+# renovate: depName=cclsp datasource=npm
+CCLSP_VERSION="0.7.0"
+
+echo "Installing cclsp ${CCLSP_VERSION}..."
+npm install -g "cclsp@${CCLSP_VERSION}"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "cclsp": {
+      "type": "stdio",
+      "command": "cclsp",
+      "env": {
+        "CCLSP_CONFIG_PATH": "/workspaces/SunGather/.claude/cclsp.json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Install `python-lsp-server` via `pipx` and `cclsp` via `npm` in `.devcontainer/setup-devcontainer.sh`
- Add `.mcp.json` to register cclsp as a stdio MCP server
- Add `.claude/cclsp.json` configuring `pylsp` for `.py` files with 30min restart interval
- Both versions have Renovate comments for automated updates

Follows the same pattern as xfg (TypeScript) and spruyt-labs (Go), adapted for Python using `pipx` to isolate pylsp from the project's pip dependencies.

## Test plan
- [x] Verified `pylsp` installs and resolves on PATH via pipx
- [x] Verified cclsp MCP server connects successfully
- [x] Ran `get_diagnostics` on all 31 `.py` files — zero errors/warnings
- [ ] Rebuild devcontainer to verify end-to-end setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)