### PR TITLE
chore(deps): pin megalinter-sungather image to digest

### DIFF
--- a/lint-config.sh
+++ b/lint-config.sh
@@ -3,8 +3,9 @@
 # Lint configuration - customize per repository
 # This file is sourced by lint.sh for both local and CI runs
 
-# MegaLinter Docker image
-MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-sungather:latest"
+# MegaLinter Docker image (use digest for reproducibility)
+# renovate: datasource=docker depName=ghcr.io/anthony-spruyt/megalinter-sungather
+MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-sungather:1.0.1@sha256:93a4d3b356b88b62f2116d617de180d1a6809b04014ec7660081d4e16b03ca00"
 
 # Skip linting for renovate/dependabot commits in CI
 SKIP_BOT_COMMITS=true


### PR DESCRIPTION
## Summary
- Pin `megalinter-sungather` Docker image from `:latest` to `1.0.1@sha256:93a4d3b...` for reproducible lint runs
- Add Renovate `datasource=docker` annotation so digest gets auto-updated

## Test plan
- [ ] `./lint.sh` runs successfully with pinned image
- [ ] Renovate detects annotation and proposes future digest updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)