### PR TITLE
chore: align release notes with container-images format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -148,7 +148,6 @@ jobs:
           VERSION: "${{ needs.resolve-version.outputs.version }}"
           DIGEST: "${{ steps.push.outputs.digest }}"
           IMAGE: "${{ env.IMAGE }}"
-          OWNER: "${{ github.repository_owner }}"
           REPO: "${{ github.repository }}"
           RUN_ID: "${{ github.run_id }}"
           SHA: "${{ github.sha }}"
@@ -177,12 +176,7 @@ jobs:
             else
               git log --pretty=format:"- %h %s" --no-merges
             fi
-            printf '\n\n'
-
-            printf '### Verify Provenance\n\n'
-            printf '```bash\n'
-            printf 'gh attestation verify oci://%s:%s --owner %s\n' "${IMAGE}" "${VERSION}" "${OWNER}"
-            printf '```\n'
+            printf '\n'
             echo 'NOTES_EOF'
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,30 +149,37 @@ jobs:
           DIGEST: "${{ steps.push.outputs.digest }}"
           IMAGE: "${{ env.IMAGE }}"
           OWNER: "${{ github.repository_owner }}"
+          REPO: "${{ github.repository }}"
+          RUN_ID: "${{ github.run_id }}"
+          SHA: "${{ github.sha }}"
         run: |
-          # Find the previous tag to generate changelog
-          # The current $TAG was already pushed, so it is first in the list — skip it
           PREV_TAG=$(git tag --list "v*" --sort=-v:refname | sed -n '2p')
+          SHORT_SHA="${SHA:0:7}"
 
           {
             echo 'RELEASE_NOTES<<NOTES_EOF'
 
-            printf '## What'\''s Changed\n\n'
+            # shellcheck disable=SC2016
+            printf '`%s:%s`\n' "${IMAGE}" "${VERSION}"
+            # shellcheck disable=SC2016
+            printf '`%s`\n\n' "${DIGEST}"
+
+            printf '```bash\n'
+            printf 'docker pull %s:%s\n' "${IMAGE}" "${VERSION}"
+            printf '```\n\n'
+
+            printf '**Platform:** linux/amd64 | **Commit:** %s | **Run:** [#%s](https://github.com/%s/actions/runs/%s)\n\n' \
+              "${SHORT_SHA}" "${RUN_ID}" "${REPO}" "${RUN_ID}"
+
+            printf '### Changes\n\n'
             if [ -n "$PREV_TAG" ]; then
-              git log "${PREV_TAG}..HEAD" --pretty=format:'- %s' --no-merges
+              git log "${PREV_TAG}..HEAD" --pretty=format:"- %h %s" --no-merges
             else
-              git log --pretty=format:'- %s' --no-merges
+              git log --pretty=format:"- %h %s" --no-merges
             fi
             printf '\n\n'
 
-            printf '## Container Image\n\n'
-            printf '```\n'
-            printf '%s:%s\n' "${IMAGE}" "${VERSION}"
-            printf '```\n\n'
-            # shellcheck disable=SC2016
-            printf '**Digest:** `%s`\n\n' "${DIGEST}"
-            printf '**Platform:** linux/amd64\n\n'
-            printf '## Verify Provenance\n\n'
+            printf '### Verify Provenance\n\n'
             printf '```bash\n'
             printf 'gh attestation verify oci://%s:%s --owner %s\n' "${IMAGE}" "${VERSION}" "${OWNER}"
             printf '```\n'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,3 +4,6 @@ http://localhost:8086/
 
 # MCP server URLs use private .lan domains with shell variable substitution
 .*\.lan/.*
+
+# Printf format string templates in release workflow
+.*%s.*

--- a/.mcp.json
+++ b/.mcp.json
@@ -13,13 +13,6 @@
       "env": {
         "CCLSP_CONFIG_PATH": "/workspaces/SunGather/.claude/cclsp.json"
       }
-    },
-    "github": {
-      "type": "http",
-      "url": "https://github-mcp.lan.${EXTERNAL_DOMAIN}/mcp",
-      "headers": {
-        "X-API-KEY": "${GITHUB_MCP_API_KEY}"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Reformatted release notes template to match container-images repo style (compact, image+digest at top, docker pull command, metadata line, commit-hash prefixed changelogs)
- Removed github MCP server entry (service deleted)
- Updated all existing releases (v1.0.0–v1.0.7) to new format, stripped verbose LLM filler and upstream git history noise from v1.0.0

## Test plan
- [ ] Trigger a patch release via workflow dispatch and verify notes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)