### PR TITLE
ci(release): harden release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,15 +21,22 @@ concurrency:
   group: "release"
   cancel-in-progress: false
 env:
+  REGISTRY: "ghcr.io"
   IMAGE: "ghcr.io/${{ github.repository_owner }}/sungather"
 jobs:
   resolve-version:
     name: "Resolve version"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 5
     outputs:
       tag: "${{ steps.bump.outputs.tag }}"
       version: "${{ steps.bump.outputs.version }}"
     steps:
+      - name: "Verify branch"
+        if: "github.ref_name != 'main'"
+        run: |
+          echo "::error::Releases must be triggered from the main branch"
+          exit 1
       - name: "Checkout"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
         with:
@@ -40,8 +47,7 @@ jobs:
         env:
           BUMP: "${{ inputs.bump }}"
         run: |
-          # Find latest tag matching v* prefix
-          LATEST=$(git tag --list "v*" --sort=-v:refname | head -n 1)
+          LATEST=$(git tag --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
 
           if [ -z "$LATEST" ]; then
             CURRENT="0.0.0"
@@ -59,11 +65,20 @@ jobs:
 
           VERSION="${MAJOR}.${MINOR}.${PATCH}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-          echo "::notice::Bumping $BUMP: ${LATEST:-v0.0.0} -> v$VERSION"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "::notice::Bumping $BUMP: ${LATEST:-0.0.0} -> $VERSION"
+      - name: "Verify tag is available"
+        env:
+          TAG: "${{ steps.bump.outputs.tag }}"
+        run: |
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "::error::Tag $TAG already exists on remote"
+            exit 1
+          fi
   test:
     name: "Test"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 15
     steps:
       - name: "Checkout"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
@@ -83,9 +98,13 @@ jobs:
       - "resolve-version"
       - "test"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     steps:
       - name: "Checkout"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: "Inject version into source"
         env:
@@ -99,7 +118,7 @@ jobs:
       - name: "Login to GHCR"
         uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121" # v4
         with:
-          registry: "ghcr.io"
+          registry: "${{ env.REGISTRY }}"
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -113,7 +132,28 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.resolve-version.outputs.tag }}
             type=raw,value=latest
 
-      - name: "Build and push"
+      - name: "Build image"
+        uses: "docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f" # v7
+        with:
+          context: "."
+          push: false
+          load: true
+          tags: "sungather:release"
+          cache-from: "type=gha"
+          cache-to: "type=gha,mode=max"
+
+      - name: "Scan for vulnerabilities"
+        uses: "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" # v0.36.0
+        with:
+          image-ref: "sungather:release"
+          scanners: "vuln,secret,misconfig"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          ignore-unfixed: true
+          trivyignores: ".trivyignore.yaml"
+
+      - name: "Push image"
         id: "push"
         uses: "docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f" # v7
         with:
@@ -148,12 +188,13 @@ jobs:
           VERSION: "${{ needs.resolve-version.outputs.version }}"
           DIGEST: "${{ steps.push.outputs.digest }}"
           IMAGE: "${{ env.IMAGE }}"
-          REPO: "${{ github.repository }}"
-          RUN_ID: "${{ github.run_id }}"
           SHA: "${{ github.sha }}"
+          RUN_NUMBER: "${{ github.run_number }}"
+          RUN_ID: "${{ github.run_id }}"
+          SERVER_URL: "${{ github.server_url }}"
+          REPO: "${{ github.repository }}"
         run: |
-          PREV_TAG=$(git tag --list "v*" --sort=-v:refname | sed -n '2p')
-          SHORT_SHA="${SHA:0:7}"
+          PREV_TAG=$(git tag --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sed -n '2p')
 
           {
             echo 'RELEASE_NOTES<<NOTES_EOF'
@@ -167,14 +208,14 @@ jobs:
             printf 'docker pull %s:%s\n' "${IMAGE}" "${VERSION}"
             printf '```\n\n'
 
-            printf '**Platform:** linux/amd64 | **Commit:** %s | **Run:** [#%s](https://github.com/%s/actions/runs/%s)\n\n' \
-              "${SHORT_SHA}" "${RUN_ID}" "${REPO}" "${RUN_ID}"
+            printf '**Platform:** linux/amd64 | **Commit:** %s | **Run:** [#%s](%s/%s/actions/runs/%s)\n\n' \
+              "${SHA}" "${RUN_NUMBER}" "${SERVER_URL}" "${REPO}" "${RUN_ID}"
 
             printf '### Changes\n\n'
             if [ -n "$PREV_TAG" ]; then
-              git log "${PREV_TAG}..HEAD" --pretty=format:"- %h %s" --no-merges
+              git log "${PREV_TAG}..HEAD" --pretty=format:'- %s' --no-merges
             else
-              git log --pretty=format:"- %h %s" --no-merges
+              printf '- Initial release\n'
             fi
             printf '\n'
             echo 'NOTES_EOF'


### PR DESCRIPTION
## Summary

- Add branch guard, tag existence check, job timeouts, and robust semver tag filtering
- Drop `v` prefix from git tags to eliminate Docker tag mismatch
- Add pre-push Trivy vulnerability scan (build local → scan → push)
- Align release notes with FireMerge format (`SERVER_URL`, `RUN_NUMBER`, cleaner commit log)
- Extract `REGISTRY` env var, add `fetch-depth: 0` to release checkout

## Reference

- Closes #156
- FireMerge PR: anthony-spruyt/firemerge#167

## Test plan

- [ ] Trigger release workflow from non-main branch → verify it fails at branch guard
- [ ] Verify `resolve-version` computes correct version from existing `v`-prefixed tags
- [ ] Verify Trivy scan runs before image push
- [ ] Verify release notes render correctly with `RUN_NUMBER` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)