### PR TITLE
feat(ci): use shared trivy-scan composite action with SARIF upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,14 +58,9 @@ jobs:
           cache-to: "type=gha,mode=max"
 
       - name: "Scan for vulnerabilities"
-        uses: "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" # v0.36.0
+        uses: "anthony-spruyt/repo-operator/.github/actions/trivy-scan@main"
         with:
           image-ref: "sungather:ci"
-          scanners: "vuln,secret,misconfig"
-          format: "table"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"
-          ignore-unfixed: true
           trivyignores: ".trivyignore.yaml"
 
   summary:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,6 @@ permissions:
   packages: "write"
   id-token: "write"
   attestations: "write"
-  security-events: "write"
 concurrency:
   group: "release"
   cancel-in-progress: false
@@ -142,12 +141,6 @@ jobs:
           tags: "sungather:release"
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
-
-      - name: "Scan for vulnerabilities"
-        uses: "anthony-spruyt/repo-operator/.github/actions/trivy-scan@main"
-        with:
-          image-ref: "sungather:release"
-          trivyignores: ".trivyignore.yaml"
 
       - name: "Push image"
         id: "push"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ permissions:
   packages: "write"
   id-token: "write"
   attestations: "write"
+  security-events: "write"
 concurrency:
   group: "release"
   cancel-in-progress: false
@@ -143,14 +144,9 @@ jobs:
           cache-to: "type=gha,mode=max"
 
       - name: "Scan for vulnerabilities"
-        uses: "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" # v0.36.0
+        uses: "anthony-spruyt/repo-operator/.github/actions/trivy-scan@main"
         with:
           image-ref: "sungather:release"
-          scanners: "vuln,secret,misconfig"
-          format: "table"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"
-          ignore-unfixed: true
           trivyignores: ".trivyignore.yaml"
 
       - name: "Push image"


### PR DESCRIPTION
## Summary
- Replace inline `aquasecurity/trivy-action` steps in CI and Release workflows with the shared `anthony-spruyt/repo-operator/.github/actions/trivy-scan@main` composite action
- Add `security-events: write` permission to `release.yaml` (CI already had it) for SARIF upload support
- Preserves existing `image-ref` and `trivyignores` values per workflow

## Linked Issue
Ref anthony-spruyt/spruyt-labs#1384

## Changes
- **ci.yaml**: Replaced 8-line inline Trivy config with 3-line composite action call (image-ref + trivyignores)
- **release.yaml**: Same replacement + added `security-events: "write"` permission for SARIF upload
- `trivy-scan.yaml` unchanged — already uses shared reusable workflows (`_trivy-fs.yaml`, `_trivy-img.yaml`)

## Testing
- CI will run on this PR and validate the composite action works
- SARIF results should appear in the Security tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)