### PR TITLE
chore(config): add agentmemory MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,15 @@
 {
   "mcpServers": {
+    "agentmemory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@agentmemory/mcp"],
+      "env": {
+        "AGENTMEMORY_URL": "${AGENTMEMORY_URL}",
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}",
+        "SAFE_CHAIN_LOGGING": "silent"
+      }
+    },
     "bravesearch": {
       "type": "http",
       "url": "https://brave-search-mcp.lan.${EXTERNAL_DOMAIN}/mcp",


### PR DESCRIPTION
## Summary
- Add `agentmemory` MCP server configuration to `.mcp.json`
- Uses stdio transport via `npx @agentmemory/mcp`
- Credentials sourced from environment variables (`AGENTMEMORY_URL`, `AGENTMEMORY_SECRET`)

## Test plan
- [x] Verify `.mcp.json` is valid JSON
- [ ] Confirm MCP server connects with valid credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)