### PR TITLE
fix(release): handle mixed v-prefix tags in version sort

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,8 @@ jobs:
         env:
           BUMP: "${{ inputs.bump }}"
         run: |
-          LATEST=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+          LATEST=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | \
+            sed 's/^v//' | sort -V | tail -n 1)
 
           if [ -z "$LATEST" ]; then
             CURRENT="0.0.0"
@@ -105,6 +106,14 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: "Capture previous tag"
+        id: "prev"
+        run: |
+          PREV_TAG=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | \
+            awk '{ n=$0; gsub(/^v/,"",n); print n" "$0 }' | sort -k1,1 -V | \
+            awk '{print $2}' | tail -n 1)
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
       - name: "Inject version into source"
         env:
@@ -183,7 +192,7 @@ jobs:
           SERVER_URL: "${{ github.server_url }}"
           REPO: "${{ github.repository }}"
         run: |
-          PREV_TAG=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 2 | head -n 1)
+          PREV_TAG="${{ steps.prev.outputs.prev_tag }}"
 
           {
             echo 'RELEASE_NOTES<<NOTES_EOF'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         env:
           BUMP: "${{ inputs.bump }}"
         run: |
-          LATEST=$(git tag --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          LATEST=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
 
           if [ -z "$LATEST" ]; then
             CURRENT="0.0.0"
@@ -183,7 +183,7 @@ jobs:
           SERVER_URL: "${{ github.server_url }}"
           REPO: "${{ github.repository }}"
         run: |
-          PREV_TAG=$(git tag --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sed -n '2p')
+          PREV_TAG=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 2 | head -n 1)
 
           {
             echo 'RELEASE_NOTES<<NOTES_EOF'


### PR DESCRIPTION
## Summary

- `git --sort=-v:refname` silently mis-sorts tags with mixed `v`/no-`v` prefixes (e.g. `1.0.8` ranked below `v1.0.7`), causing LATEST to resolve wrong and the patch bump to recompute an already-existing tag
- Switch both tag lookups to `sort -V` which correctly orders mixed-prefix semver tags

## Root cause

Run [#26328376531](https://github.com/anthony-spruyt/SunGather/actions/runs/26328376531) failed with `Tag 1.0.8 already exists on remote`. Tag `1.0.8` (no `v`) was already pushed but git's version sort ranked it below `v1.0.7`, so LATEST resolved to `v1.0.7` → computed `1.0.8` → conflict.

## Test plan

- [ ] Trigger patch release — should detect `1.1.0` as latest and compute `1.1.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to more reliably determine the latest semantic version tag and capture the previous tag.
  * Updated release notes generation to use the captured previous tag, making releases and changelogs more consistent and robust.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anthony-spruyt/SunGather/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->